### PR TITLE
step any frames in one tick

### DIFF
--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -298,8 +298,11 @@ open class APNGImageView: APNGView {
         lastTimestamp = timestamp
         
         currentPassedDuration += elapsedTime
+        if let duration = image.duration, currentPassedDuration > duration {
+            currentPassedDuration = currentPassedDuration.truncatingRemainder(dividingBy: duration)
+        }
         
-        if currentPassedDuration >= currentFrameDuration {
+        while currentPassedDuration >= currentFrameDuration {
             currentFrameIndex = currentFrameIndex + 1
             
             if currentFrameIndex == image.frameCount {


### PR DESCRIPTION
## 問題点
バックグラウンド復帰時などにアニメーションが速い

## 原因
現状の実装では自前のRunLoopタイマーで定期的にstepを回しているが、バックグラウンド復帰時などにstep間隔が膨大になる ( `elapsedTime` がめちゃでかくなる )

ここで、 `tick()` 1stepで1フレームしか進めない実装になっているため `elapsedTime` が大きいときに毎stepごとにアニメーションが進むことになってしまう。本来は経過時間が大きかったらその分アニメーションも進めるべきである
逆に60fps以上のAPNGを再生しようとしたときに現状の実装ではスローモーションになってしまう。これは同様に1stepで1フレームしか進めれない実装になっているためである。


経過時間が膨大なときに負荷が線形に増加するのはよくないため、アニメーションのフレーム数をNとしてO(N)になるように経過時間を調整する処理をいれた。これにより `repeated` や delegate  が呼ばれる回数が本来の経過時間に対応した数にならないが、仕様として本来はバックグラウンドにいっている間はアニメーションを停止させている想定のようなので（実際は止まっていないが）問題ないものとしている